### PR TITLE
Fix limit argument type in rep weight script

### DIFF
--- a/ci/record_rep_weights.py
+++ b/ci/record_rep_weights.py
@@ -1,6 +1,5 @@
 import requests
 import argparse
-from binascii import unhexlify
 from base64 import b32decode
 from binascii import hexlify, unhexlify
 
@@ -11,7 +10,7 @@ parser.add_argument("output", type=str, help="output weight file")
 parser.add_argument("--rpc", help="node rpc host:port",
                     default="http://[::1]:7076")
 parser.add_argument(
-    "--limit", help="percentage of the active supply represented", default=0.99)
+    "--limit", help="percentage of the active supply represented", default=0.99, type=float)
 parser.add_argument(
     "--cutoff", help="stop using bootstrap reps this many blocks before the current block height", default=250000, type=int)
 args = parser.parse_args()


### PR DESCRIPTION
## Summary
- fix `--limit` flag's type in `record_rep_weights.py`
- clean up duplicate imports

## Testing
- `python3 -m py_compile ci/record_rep_weights.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3a6f6180832e852c0d92da9d207b